### PR TITLE
Fix indeterminate density ratios

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -5,14 +5,14 @@ branches:
 env:
   global:
   - RGL_USE_NULL=TRUE
+  - secure: TF4+d5Jj4KrwoEt7a8z0kk0+Y0K6ScKQpuAnGFFp/dSuNLPX76UmIIbKNWA/JhDpgdNyecHdwV+HRPgMj5/wDfokLX7IUMFdpWldDy84Df/m38T2fogspjFa7k3eMeucoOL8q79IUayuRq3g8qGaxa0Sm/JhFJcpqSdyrjAk5qNBDCrt9EcQB92PpiZnWCg4GHHAnegAFEtmmB2QLve6dwhPMS2kAa0mqRWNJVFhpnaNIn1A5rn3FfShtc4ccVfbYqSt7wMAKttjz+FnVSj42zR4IftoHXB1Jvfvdrh1K5iGuiSmiQoS4sxG1ktzqvkRDbRbxZ4GKT8VQ9DsISL3sALbpAyafLjdmxf76YGMldRztPAvkdgZMBPpvBer6x2fEkLgpq4MEnTwfhBABMwMoXUt/p3ed/HtrjTtlzUttZpQHvL+OgOguo6ZzfDSCWbChGU5v/d3at0xRCO0QJoClxZ1lhNn+5jpaH2VcTRidel4Yr3Y7HfJOumHO21mFjC87lHKqZZBcWd33s3Y2Km9AuYcy3pLM3BfU7BlAyUsEhUniaFFVC9yMj4LOuYTG1xjFkuvM7ZAn80bcXfz4JKmEDjzG9DxQDaETARdJfyIG+vsx+xmej1LaoHBeuIxfCRcMKZJzvXlq9aZCwSl8Ps/RequfJWRsyn2TXieDxGOP4Q=
 
 language: r
 sudo: required
 cache: packages
 warnings_are_errors: true
-
-r_build_args: '--no-manual'
-r_check_args: '--no-build-vignettes --no-manual'
+r_build_args: "--no-manual"
+r_check_args: "--no-build-vignettes --no-manual"
 
 r:
   - release

--- a/.travis.yml
+++ b/.travis.yml
@@ -28,7 +28,7 @@ r_packages:
   - data.table
 
 r_github_packages:
-  - r-lib/devtools@2d012d1
+  - r-lib/devtools
   - r-lib/sessioninfo
   - Rdatatable/data.table
   - jimhester/covr

--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -45,12 +45,14 @@ Suggests:
     stats,
     ggplot2,
     tidyverse,
+    simcausal,
     condensier,
     txshift,
     Rsolnp,
     nnls,
     ranger
 Remotes:
+    github::osofr/simcausal,
     github::osofr/condensier,
     github::nhejazi/txshift,
     github::tlverse/origami,

--- a/R/shift_density_bounded.R
+++ b/R/shift_density_bounded.R
@@ -33,6 +33,12 @@ shift_additive_bounded <- function(tmle_task, delta, likelihood_base,
     likelihood_base
   )
 
+  # set NA values to 0 for density comparison
+  na_mask_intervention_density_ratio <- is.na(intervention_density_ratio)
+  if (FALSE %in% na_mask_intervention_density_ratio) {
+    intervention_density_ratio[na_mask_intervention_density_ratio] <- 0
+  }
+
   # compute realistic value of intervention
   observed_a <- tmle_task$get_tmle_node("A")
   shift_amt <- ifelse(intervention_density_ratio < max_shifted_ratio, delta, 0)
@@ -53,6 +59,12 @@ shift_additive_bounded_inv <- function(tmle_task, delta, likelihood_base,
     tmle_task, delta,
     likelihood_base
   )
+
+  # set NA values to 0 for density comparison
+  na_mask_intervention_density_ratio <- is.na(intervention_density_ratio)
+  if (FALSE %in% na_mask_intervention_density_ratio) {
+    intervention_density_ratio[na_mask_intervention_density_ratio] <- 0
+  }
 
   # compute realistic value of intervention
   observed_a <- tmle_task$get_tmle_node("A")

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -15,6 +15,8 @@ environment:
     WARNINGS_ARE_ERRORS: 0
     R_ARCH: x64
     USE_RTOOLS: true
+    GITHUB_PAT:
+      secure: mW3puUbGi4Q8x4bRzDxlV8FWIIrCPzrg5QXzGKnEx+O092df4uUmbmfkQaFQ3DJY
 
 cache:
   - C:\RLibrary

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -17,12 +17,12 @@ environment:
     USE_RTOOLS: true
 
 cache:
-  - C:\RLibrary -> appveyor.yml
+  - C:\RLibrary
 
 # Adapt as necessary starting from here
 build_script:
   - travis-tool.sh install_deps
-  - travis-tool.sh install_github r-lib/devtools@2d012d1
+  - travis-tool.sh install_github r-lib/devtools
   - travis-tool.sh install_github r-lib/sessioninfo
   - travis-tool.sh install_github Rdatatable/data.table
   - travis-tool.sh install_github jimhester/covr

--- a/docs/articles/shift_tmle.html
+++ b/docs/articles/shift_tmle.html
@@ -81,7 +81,7 @@
 <a href="https://nimahejazi.org">Nima Hejazi</a>, <a href="https://www.benkeserstatistics.com/">David Benkeser</a>, and <a href="https://github.com/jeremyrcoyle">Jeremy Coyle</a>
 </h4>
             
-            <h4 class="date">2018-10-10</h4>
+            <h4 class="date">2018-10-24</h4>
       
       
       <div class="hidden name"><code>shift_tmle.Rmd</code></div>
@@ -198,12 +198,12 @@
 <a href="#targeted-estimation-of-stochastic-interventions-effects" class="anchor"></a>Targeted Estimation of Stochastic Interventions Effects</h3>
 <div class="sourceCode" id="cb8"><pre class="sourceCode r"><code class="sourceCode r"><a class="sourceLine" id="cb8-1" data-line-number="1">tmle_fit &lt;-<span class="st"> </span><span class="kw"><a href="http://www.rdocumentation.org/packages/tmle3/topics/tmle3">tmle3</a></span>(tmle_spec, data, node_list, learner_list)</a></code></pre></div>
 <pre><code>## 
-## Iter: 1 fn: 1829.0370     Pars:  0.89608896 0.10389031 0.00002072
-## Iter: 2 fn: 1829.0370     Pars:  0.89609185 0.10389521 0.00001294
+## Iter: 1 fn: 1829.0370     Pars:  0.89609235 0.10389606 0.00001158
+## Iter: 2 fn: 1829.0370     Pars:  0.896093725 0.103899682 0.000006593
 ## solnp--&gt; Completed in 2 iterations</code></pre>
 <div class="sourceCode" id="cb10"><pre class="sourceCode r"><code class="sourceCode r"><a class="sourceLine" id="cb10-1" data-line-number="1">tmle_fit</a></code></pre></div>
-<pre><code>##    type         param init_est tmle_est        se    lower    upper
-## 1:  TSM E[Y_{A=NULL}] 2.029112  2.03477 0.0648038 1.907757 2.161783
+<pre><code>##    type         param init_est tmle_est         se    lower    upper
+## 1:  TSM E[Y_{A=NULL}] 2.029112  2.03477 0.06480381 1.907757 2.161783
 ##    psi_transformed lower_transformed upper_transformed
 ## 1:         2.03477          1.907757          2.161783</code></pre>
 <p>The <code>print</code> method of the resultant <code>tmle_fit</code> object conveniently displays the results from computing our TML estimator.</p>
@@ -224,8 +224,8 @@
 <p><span class="math display">\[\sigma_n^2 = \frac{1}{n} \sum_{i = 1}^{n} D^2(\bar{Q}_n^*, g_n)(O_i)\]</span></p>
 <p>Having now re-examined these facts, let’s simply examine the results of computing our TML estimator:</p>
 <div class="sourceCode" id="cb12"><pre class="sourceCode r"><code class="sourceCode r"><a class="sourceLine" id="cb12-1" data-line-number="1">tmle_fit</a></code></pre></div>
-<pre><code>##    type         param init_est tmle_est        se    lower    upper
-## 1:  TSM E[Y_{A=NULL}] 2.029112  2.03477 0.0648038 1.907757 2.161783
+<pre><code>##    type         param init_est tmle_est         se    lower    upper
+## 1:  TSM E[Y_{A=NULL}] 2.029112  2.03477 0.06480381 1.907757 2.161783
 ##    psi_transformed lower_transformed upper_transformed
 ## 1:         2.03477          1.907757          2.161783</code></pre>
 </div>

--- a/docs/articles/vimshift.html
+++ b/docs/articles/vimshift.html
@@ -81,7 +81,7 @@
 <a href="https://nimahejazi.org">Nima S. Hejazi</a>, <a href="https://github.com/jeremyrcoyle">Jeremy R. Coyle</a>, and <a href="https://vanderlaan-lab.org">Mark J. van der Laan</a>
 </h4>
             
-            <h4 class="date">2018-10-10</h4>
+            <h4 class="date">2018-10-24</h4>
       
       
       <div class="hidden name"><code>vimshift.Rmd</code></div>
@@ -253,26 +253,26 @@
 <div class="sourceCode" id="cb9"><pre class="sourceCode r"><code class="sourceCode r"><a class="sourceLine" id="cb9-1" data-line-number="1"><span class="co"># fit the TML estimator</span></a>
 <a class="sourceLine" id="cb9-2" data-line-number="2">tmle_fit &lt;-<span class="st"> </span><span class="kw"><a href="http://www.rdocumentation.org/packages/tmle3/topics/tmle3">tmle3</a></span>(tmle_spec, data, node_list, learner_list)</a></code></pre></div>
 <pre><code>## 
-## Iter: 1 fn: 1834.2934     Pars:  0.09403194 0.02130001 0.00002312 0.88464494
-## Iter: 2 fn: 1834.2934     Pars:  0.09403798 0.02130289 0.00001423 0.88464490
+## Iter: 1 fn: 1834.2719     Pars:  0.09216332 0.02402433 0.00004324 0.88376911
+## Iter: 2 fn: 1834.2718     Pars:  0.09217750 0.02403054 0.00002222 0.88376973
 ## solnp--&gt; Completed in 2 iterations</code></pre>
 <div class="sourceCode" id="cb11"><pre class="sourceCode r"><code class="sourceCode r"><a class="sourceLine" id="cb11-1" data-line-number="1">tmle_fit</a></code></pre></div>
 <pre><code>##          type          param  init_est  tmle_est         se     lower
-## 1:        TSM  E[Y_{A=NULL}] 0.6011976 0.5992119 0.06323217 0.4752792
-## 2:        TSM  E[Y_{A=NULL}] 1.0377049 1.0328285 0.06722522 0.9010694
+## 1:        TSM  E[Y_{A=NULL}] 0.6011976 0.5992044 0.06323787 0.4752605
+## 2:        TSM  E[Y_{A=NULL}] 1.0377049 1.0328160 0.06722456 0.9010583
 ## 3:        TSM  E[Y_{A=NULL}] 1.5431887 1.5432763 0.06656993 1.4128016
-## 4:        TSM  E[Y_{A=NULL}] 2.0347742 2.0305806 0.06505842 1.9030685
-## 5:        TSM  E[Y_{A=NULL}] 2.4944453 2.4869943 0.06083826 2.3677535
-## 6: MSM_linear MSM(intercept) 1.5427416 1.5389140 0.06343542 1.4145828
-## 7: MSM_linear     MSM(slope) 0.9556543 0.9536458 0.01304592 0.9280762
+## 4:        TSM  E[Y_{A=NULL}] 2.0347742 2.0305620 0.06505555 1.9030554
+## 5:        TSM  E[Y_{A=NULL}] 2.4944453 2.4869662 0.06083687 2.3677281
+## 6: MSM_linear MSM(intercept) 1.5427412 1.5388999 0.06343582 1.4145680
+## 7: MSM_linear     MSM(slope) 0.9556556 0.9536373 0.01305091 0.9280580
 ##        upper psi_transformed lower_transformed upper_transformed
-## 1: 0.7231447       0.5992119         0.4752792         0.7231447
-## 2: 1.1645875       1.0328285         0.9010694         1.1645875
+## 1: 0.7231484       0.5992044         0.4752605         0.7231484
+## 2: 1.1645737       1.0328160         0.9010583         1.1645737
 ## 3: 1.6737509       1.5432763         1.4128016         1.6737509
-## 4: 2.1580928       2.0305806         1.9030685         2.1580928
-## 5: 2.6062351       2.4869943         2.3677535         2.6062351
-## 6: 1.6632451       1.5389140         1.4145828         1.6632451
-## 7: 0.9792153       0.9536458         0.9280762         0.9792153</code></pre>
+## 4: 2.1580685       2.0305620         1.9030554         2.1580685
+## 5: 2.6062042       2.4869662         2.3677281         2.6062042
+## 6: 1.6632318       1.5388999         1.4145680         1.6632318
+## 7: 0.9792166       0.9536373         0.9280580         0.9792166</code></pre>
 <p><em>Remark</em>: The <code>print</code> method of the resultant <code>tmle_fit</code> object conveniently displays the results from computing our TML estimator.</p>
 </div>
 <div id="inference-with-marginal-structural-models" class="section level3">
@@ -301,12 +301,12 @@ m_{\beta}(\delta))\right)h(\delta),\]</span> where <span class="math inline">\(\
 - m_{\beta}(\delta)) = 0.\]</span></p>
 <p>Inference from a working MSM is rather straightforward. To wit, the limiting distribution for <span class="math inline">\(m_{\beta}(\delta)\)</span> may be expressed <span class="math display">\[\sqrt{n}(\beta_n - \beta_0) \to N(0, \Sigma),\]</span> where <span class="math inline">\(\Sigma\)</span> is the empirical covariance matrix of <span class="math inline">\(\text{EIF}_{\beta}(O)\)</span>.</p>
 <div class="sourceCode" id="cb13"><pre class="sourceCode r"><code class="sourceCode r"><a class="sourceLine" id="cb13-1" data-line-number="1">tmle_fit<span class="op">$</span>summary[<span class="dv">6</span><span class="op">:</span><span class="dv">7</span>,]</a></code></pre></div>
-<pre><code>##          type          param  init_est  tmle_est         se     lower
-## 1: MSM_linear MSM(intercept) 1.5427416 1.5389140 0.06343542 1.4145828
-## 2: MSM_linear     MSM(slope) 0.9556543 0.9536458 0.01304592 0.9280762
+<pre><code>##          type          param  init_est  tmle_est         se    lower
+## 1: MSM_linear MSM(intercept) 1.5427412 1.5388999 0.06343582 1.414568
+## 2: MSM_linear     MSM(slope) 0.9556556 0.9536373 0.01305091 0.928058
 ##        upper psi_transformed lower_transformed upper_transformed
-## 1: 1.6632451       1.5389140         1.4145828         1.6632451
-## 2: 0.9792153       0.9536458         0.9280762         0.9792153</code></pre>
+## 1: 1.6632318       1.5388999          1.414568         1.6632318
+## 2: 0.9792166       0.9536373          0.928058         0.9792166</code></pre>
 <div id="directly-targeting-the-msm-parameter-beta" class="section level4">
 <h4 class="hasAnchor">
 <a href="#directly-targeting-the-msm-parameter-beta" class="anchor"></a>Directly Targeting the MSM Parameter <span class="math inline">\(\beta\)</span>
@@ -329,8 +329,8 @@ H_2(g),\]</span> for all <span class="math inline">\(\delta\)</span>, where <spa
 <a class="sourceLine" id="cb15-8" data-line-number="8"><span class="co"># fit the TML estimator and examine the results</span></a>
 <a class="sourceLine" id="cb15-9" data-line-number="9">tmle_msm_fit &lt;-<span class="st"> </span><span class="kw"><a href="http://www.rdocumentation.org/packages/tmle3/topics/tmle3">tmle3</a></span>(tmle_msm_spec, data, node_list, learner_list)</a></code></pre></div>
 <pre><code>## 
-## Iter: 1 fn: 1860.7946     Pars:  0.001018619 0.000002573 0.107351910 0.891626895
-## Iter: 2 fn: 1860.7946     Pars:  0.0009773585 0.0000003529 0.1073901097 0.8916321789
+## Iter: 1 fn: 1860.7946     Pars:  0.001018954 0.000002283 0.107351823 0.891626936
+## Iter: 2 fn: 1860.7946     Pars:  0.0009773865 0.0000003161 0.1073901107 0.8916321868
 ## solnp--&gt; Completed in 2 iterations</code></pre>
 <div class="sourceCode" id="cb17"><pre class="sourceCode r"><code class="sourceCode r"><a class="sourceLine" id="cb17-1" data-line-number="1">tmle_msm_fit</a></code></pre></div>
 <pre><code>##          type          param init_est tmle_est         se     lower

--- a/tests/testthat/test-shift_additive_simple.R
+++ b/tests/testthat/test-shift_additive_simple.R
@@ -17,6 +17,7 @@ set.seed(429153)
 n_obs <- 1000 # number of observations
 n_w <- 1 # number of baseline covariates
 tx_mult <- 2 # multiplier for the effect of W = 1 on the treatment
+delta_value <- 0.5 # value of the shift parameter
 
 ## baseline covariates -- simple, binary
 W <- as.numeric(replicate(n_w, rbinom(n_obs, 1, 0.5)))
@@ -71,7 +72,7 @@ learner_list <- list(Y = Q_learner, A = g_learner)
 
 # initialize a tmle specification
 tmle_spec <- tmle_shift(
-  shift_val = 0.5,
+  shift_val = delta_value,
   shift_fxn = shift_additive,
   shift_fxn_inv = shift_additive_inv
 )
@@ -107,7 +108,7 @@ set.seed(429153)
 
 ## TODO: validate that we're getting the same errors on g fitting
 tmle_sl_shift_classic <- tmle_txshift(
-  W = W, A = A, Y = Y, delta = 0.5,
+  W = W, A = A, Y = Y, delta = delta_value,
   fluc_method = "weighted",
   g_fit_args = list(
     fit_type = "sl",


### PR DESCRIPTION
Sometimes, density ratios in `shift_density_bounded` return `NA` when comparing the counterfactual and observed probability of the intervention given the covariates (for some observations only). This causes failures to propagate throughout the remainder of the estimation procedure.