### PR TITLE
Disable cvtmle in specs

### DIFF
--- a/R/tmle3_Spec_shift.R
+++ b/R/tmle3_Spec_shift.R
@@ -61,6 +61,9 @@ tmle3_Spec_shift <- R6::R6Class(
       # output should be a list
       tmle_params <- list(shifted_mean)
       return(tmle_params)
+    },
+    make_updater = function() {
+      updater <- tmle3_Update$new(cvtmle = FALSE)
     }
   ),
   active = list(),

--- a/R/tmle3_Spec_vimshift_delta.R
+++ b/R/tmle3_Spec_vimshift_delta.R
@@ -79,6 +79,9 @@ tmle3_Spec_vimshift_delta <- R6::R6Class(
 
       # output should be a list
       return(tmle_params)
+    },
+    make_updater = function() {
+      updater <- tmle3_Update$new(cvtmle = FALSE)
     }
   ),
   active = list(),

--- a/R/tmle3_Spec_vimshift_msm.R
+++ b/R/tmle3_Spec_vimshift_msm.R
@@ -79,6 +79,9 @@ tmle3_Spec_vimshift_msm <- R6::R6Class(
 
       # output should be a list
       return(msm_linear_param)
+    },
+    make_updater = function() {
+      updater <- tmle3_Update$new(cvtmle = FALSE)
     }
   ),
   active = list(),

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -16,7 +16,7 @@ environment:
     R_ARCH: x64
     USE_RTOOLS: true
     GITHUB_PAT:
-      secure: mW3puUbGi4Q8x4bRzDxlV8FWIIrCPzrg5QXzGKnEx+O092df4uUmbmfkQaFQ3DJY
+      secure: Nu6c5CmcVdYHDUVGej5ZIXGKOXVPBwqUwjrLV8d6UlbUaAtYuUhgpNuv9oLztAQQ
 
 cache:
   - C:\RLibrary


### PR DESCRIPTION
This resolves https://github.com/tlverse/tmle3shift/issues/16

In https://github.com/tlverse/tmle3/pull/25 the default for `tmle3` changed from standard to cv-tmle, as the cv-tmle implementation is now stable, and has better asymptotic properties. This PR overrides that default in all the `tmle3shift` specs to standard tmle. This allows tests to match output from `txshift`. This fixes the test, but reverts `tmle3shift` to using standard tmle everywhere. Long term, we should have re-enable cv-tmle for `tmle3shift` by default, and only use standard tmle for comparison with older packages and where it makes sense in simulation.